### PR TITLE
Allow structs to implement access

### DIFF
--- a/lib/bubble_lib/dsl_struct.ex
+++ b/lib/bubble_lib/dsl_struct.ex
@@ -27,10 +27,22 @@ defmodule BubbleLib.DslStruct do
       defoverridable fetch: 2
 
       @impl Access
-      defdelegate get_and_update(a, b, c), to: Map
+      def get_and_update(term, key, fun) when key in unquote(str_fields) do
+        get_and_update(term, String.to_atom(key), fun)
+      end
+
+      def get_and_update(term, key, fun), do: Map.get_and_update(term, key, fun)
+
+      defoverridable get_and_update: 3
 
       @impl Access
-      defdelegate pop(a, b), to: Map
+      def pop(term, key) when key in unquote(str_fields) do
+        pop(term, String.to_atom(key))
+      end
+
+      def pop(term, key), do: Map.pop(term, key)
+
+      defoverridable pop: 2
 
       def __jason_encode__(struct, opts, only) do
         struct

--- a/lib/bubble_lib/map_util/auto_map.ex
+++ b/lib/bubble_lib/map_util/auto_map.ex
@@ -25,21 +25,24 @@ defmodule BubbleLib.MapUtil.AutoMap do
   defp kernel_get_and_update_in(data, [head | tail], fun) when is_function(fun, 1),
     do: access_get_and_update(data, head, &kernel_get_and_update_in(&1, tail, fun))
 
-  defp access_get_and_update(%{__struct__: _} = struct, key, fun) when is_binary(key) do
-    try do
-      key = String.to_existing_atom(key)
+  defp access_get_and_update(%module{} = struct, key, fun) when is_binary(key) do
+    module.get_and_update(struct, key, fun)
+  rescue
+    UndefinedFunctionError ->
+      try do
+        key = String.to_existing_atom(key)
 
-      case Map.fetch(struct, key) do
-        {:ok, _} ->
-          {nil, _value} = Map.get_and_update(struct, key, fun)
+        case Map.fetch(struct, key) do
+          {:ok, _} ->
+            {nil, _value} = Map.get_and_update(struct, key, fun)
 
-        :error ->
+          :error ->
+            {nil, struct}
+        end
+      rescue
+        ArgumentError ->
           {nil, struct}
       end
-    rescue
-      ArgumentError ->
-        {nil, struct}
-    end
   end
 
   defp access_get_and_update(map, key, fun) when is_map(map) and is_atom(key) do

--- a/test/bubble_lib/map_util/auto_map_test.exs
+++ b/test/bubble_lib/map_util/auto_map_test.exs
@@ -5,6 +5,15 @@ defmodule BubbleLib.MapUtil.AutoMapTest do
     defstruct [:lat, :lon]
   end
 
+  defmodule WithAccess do
+    defstruct [:name]
+    @behaviour Access
+
+    def fetch(term, key), do: Map.get(term, key)
+    def pop(data, key), do: Map.pop(data, key)
+    def get_and_update(data, "name", fun), do: Map.get_and_update(data, :name, fun)
+  end
+
   alias BubbleLib.MapUtil.AutoMap
 
   test "put in" do
@@ -15,6 +24,14 @@ defmodule BubbleLib.MapUtil.AutoMapTest do
     assert %{"a" => %{}} == AutoMap.put_in(%{"a" => %{"b" => 1}}, [:a], %{})
     assert %{"a" => %{"c" => 2}} == AutoMap.put_in(%{"a" => %{"b" => 1}}, [:a], %{"c" => 2})
     assert %{"payload" => "aap"} == AutoMap.put_in(%{"payload" => %{"x" => 2}}, [:payload], "aap")
+
+    assert %{"struct" => %WithAccess{name: "aap"}} =
+             AutoMap.put_in(%{"struct" => %WithAccess{}}, ["struct", :name], "aap")
+
+    assert_raise FunctionClauseError, fn ->
+      assert %{"struct" => %WithAccess{name: "aap"}} =
+               AutoMap.put_in(%{"struct" => %WithAccess{}}, ["struct", :nope], "aap")
+    end
   end
 
   test "put in w/ array" do


### PR DESCRIPTION
To keep compatibility with the old implementation, the dsl_struct has been changed to do the string->atom key conversion in all of the access functions. The only difference now should be that an unknown struct key being assigned to the struct will result in a string key being added to the map. For example:

```
defmodule Obj do
  use DslStruct, key: nil
end

# pseudo; assume access protocol
obj = %Obj{}
obj["key"] = 5
obj.key == 5

obj["unknown"] = 6 # AutoMap would have ignored this key
obj["unknown"] == 6
```